### PR TITLE
Fix authentication redirect URLs to use production domain

### DIFF
--- a/src/app/api/subscription/upgrade/route.ts
+++ b/src/app/api/subscription/upgrade/route.ts
@@ -120,6 +120,7 @@ export async function POST(request: NextRequest) {
         points: newPlan.points?.toString() || '0',
         billingPeriod: newPlan.duration_type
       },
+      // 传递当前登录用户的邮箱
       customer_email: userData.user.email || undefined,
       allow_promotion_codes: true,
       billing_address_collection: 'auto',

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -10,7 +10,8 @@ export async function GET(request: NextRequest) {
   // 如果有错误，记录并重定向
   if (error) {
     console.error('OAuth callback error:', error, error_description);
-    return NextResponse.redirect(`${requestUrl.origin}/?auth_error=${encodeURIComponent(error_description || error)}`);
+    const errorRedirectUrl = process.env.NEXT_PUBLIC_SITE_URL || requestUrl.origin;
+    return NextResponse.redirect(`${errorRedirectUrl}/?auth_error=${encodeURIComponent(error_description || error)}`);
   }
 
   // 如果有code，交换token
@@ -20,16 +21,21 @@ export async function GET(request: NextRequest) {
       
       if (exchangeError) {
         console.error('Error exchanging code for session:', exchangeError);
-        return NextResponse.redirect(`${requestUrl.origin}/?auth_error=session_exchange_failed`);
+        const errorRedirectUrl = process.env.NEXT_PUBLIC_SITE_URL || requestUrl.origin;
+        return NextResponse.redirect(`${errorRedirectUrl}/?auth_error=session_exchange_failed`);
       }
 
       console.log('Successfully authenticated user');
     } catch (err) {
       console.error('Unexpected error during auth callback:', err);
-      return NextResponse.redirect(`${requestUrl.origin}/?auth_error=unexpected_error`);
+      const errorRedirectUrl = process.env.NEXT_PUBLIC_SITE_URL || requestUrl.origin;
+      return NextResponse.redirect(`${errorRedirectUrl}/?auth_error=unexpected_error`);
     }
   }
 
-  // 成功后重定向到首页
-  return NextResponse.redirect(requestUrl.origin);
+  // 成功后重定向到generator页面
+  const redirectUrl = process.env.NEXT_PUBLIC_SITE_URL 
+    ? `${process.env.NEXT_PUBLIC_SITE_URL}/generator`
+    : `${requestUrl.origin}/generator`;
+  return NextResponse.redirect(redirectUrl);
 }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -121,7 +121,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             access_type: 'offline',
             prompt: 'consent',
           },
-          redirectTo: `${window.location.origin}${redirectPath}`,
+          redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || window.location.origin}${redirectPath}`,
         },
       });
 


### PR DESCRIPTION
- Updated OAuth redirect in AuthContext to use NEXT_PUBLIC_SITE_URL instead of window.location.origin
- Fixed auth callback route to redirect to production domain after successful login
- Ensured all error redirects also use the production URL
- Removed STRIPE_SITE_IDENTIFIER from .env.local as it's no longer needed

This fixes the issue where logging in from https://aiqwen.cc/ would redirect to localhost.

🤖 Generated with [Claude Code](https://claude.ai/code)